### PR TITLE
implement basic flash on hit indicator with a simple shader

### DIFF
--- a/bosses/boss_1.gd
+++ b/bosses/boss_1.gd
@@ -29,4 +29,12 @@ func _on_body_entered(body: Node2D) -> void:
 	if (body.is_in_group("player_projectiles")):
 		health -= 1
 		hit.emit()
+		
+		$FlashHitTimer.start()
+		$AnimatedSprite2D.material.set_shader_parameter("flash_modifier", 0.5)
+		
 		body.queue_free()
+
+
+func _on_flash_hit_timer_timeout() -> void:
+	$AnimatedSprite2D.material.set_shader_parameter("flash_modifier", 0)

--- a/bosses/boss_1.tscn
+++ b/bosses/boss_1.tscn
@@ -1,8 +1,16 @@
-[gd_scene load_steps=7 format=3 uid="uid://dfhnk0yjllq07"]
+[gd_scene load_steps=10 format=3 uid="uid://dfhnk0yjllq07"]
 
 [ext_resource type="Texture2D" uid="uid://d12wfe3j1m3ee" path="res://art/enemyFlyingAlt_1.png" id="1_2nlvs"]
 [ext_resource type="Script" uid="uid://bee70b3knglw5" path="res://bosses/boss_1.gd" id="1_fsng5"]
+[ext_resource type="PackedScene" uid="uid://rpvfyvfaemfy" path="res://bosses/basic_laser_beam.tscn" id="2_p7pij"]
+[ext_resource type="Shader" uid="uid://bhh5naq1x7pmc" path="res://shaders/flash_hit.gdshader" id="2_qnsdo"]
 [ext_resource type="Texture2D" uid="uid://du3fbtda0uqom" path="res://art/enemyFlyingAlt_2.png" id="2_y66il"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_l5ia4"]
+resource_local_to_scene = true
+shader = ExtResource("2_qnsdo")
+shader_parameter/flash_color = Color(1, 1, 1, 1)
+shader_parameter/flash_modifier = 0.0
 
 [sub_resource type="SpriteFrames" id="SpriteFrames_p7pij"]
 animations = [{
@@ -31,9 +39,11 @@ point_count = 5
 [node name="Boss1" type="Area2D"]
 collision_mask = 2
 script = ExtResource("1_fsng5")
+laser = ExtResource("2_p7pij")
 metadata/_edit_group_ = true
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+material = SubResource("ShaderMaterial_l5ia4")
 scale = Vector2(4, 4)
 sprite_frames = SubResource("SpriteFrames_p7pij")
 autoplay = "default"
@@ -54,5 +64,10 @@ rotation = 1.5708
 [node name="LaserBeamCD" type="Timer" parent="."]
 wait_time = 2.0
 
+[node name="FlashHitTimer" type="Timer" parent="."]
+wait_time = 0.2
+one_shot = true
+
 [connection signal="body_entered" from="." to="." method="_on_body_entered"]
 [connection signal="timeout" from="LaserBeamCD" to="." method="_on_laser_beam_cd_timeout"]
+[connection signal="timeout" from="FlashHitTimer" to="." method="_on_flash_hit_timer_timeout"]

--- a/player/player.gd
+++ b/player/player.gd
@@ -40,6 +40,10 @@ func _on_body_entered(body: Node2D):
 	if (body.is_in_group("enemy_projectiles")):
 		$CollisionShape2D.set_deferred("disabled", true)
 		$InvulTimer.start()
+
+		$FlashHitTimer.start()
+		$AnimatedSprite2D.material.set_shader_parameter("flash_modifier", 0.5)
+		
 		health -= 1
 		hit.emit()
 		body.queue_free()
@@ -51,3 +55,7 @@ func _on_weapon_cd_timeout():
 	var bullet = Bullet.instantiate()
 	bullet.position = position
 	owner.add_child(bullet)
+
+
+func _on_flash_hit_timer_timeout() -> void:
+	$AnimatedSprite2D.material.set_shader_parameter("flash_modifier", 0)

--- a/player/player.tscn
+++ b/player/player.tscn
@@ -1,8 +1,15 @@
-[gd_scene load_steps=6 format=3 uid="uid://t2wgnk2pyono"]
+[gd_scene load_steps=9 format=3 uid="uid://t2wgnk2pyono"]
 
 [ext_resource type="Script" uid="uid://dfpo4jlitdpyf" path="res://player/player.gd" id="1_g1dw6"]
 [ext_resource type="Texture2D" uid="uid://bfydf8haqsjto" path="res://art/playerGrey_walk1.png" id="2_hqtel"]
+[ext_resource type="PackedScene" uid="uid://cwdins0unq06a" path="res://player/weapons/projectile.tscn" id="2_sweqy"]
+[ext_resource type="Shader" uid="uid://bhh5naq1x7pmc" path="res://shaders/flash_hit.gdshader" id="3_qjkh3"]
 [ext_resource type="Texture2D" uid="uid://bn0n0uh4hsyxe" path="res://art/playerGrey_walk2.png" id="3_sweqy"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_g6k8r"]
+shader = ExtResource("3_qjkh3")
+shader_parameter/flash_color = Color(1, 1, 1, 1)
+shader_parameter/flash_modifier = 0.0
 
 [sub_resource type="SpriteFrames" id="SpriteFrames_2hs0m"]
 animations = [{
@@ -25,9 +32,11 @@ height = 126.0
 [node name="Player" type="Area2D"]
 collision_mask = 2
 script = ExtResource("1_g1dw6")
+Bullet = ExtResource("2_sweqy")
 metadata/_edit_group_ = true
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+material = SubResource("ShaderMaterial_g6k8r")
 sprite_frames = SubResource("SpriteFrames_2hs0m")
 animation = &"walk"
 frame = 1
@@ -44,6 +53,11 @@ wait_time = 2.0
 
 [node name="Marker2D" type="Marker2D" parent="."]
 
+[node name="FlashHitTimer" type="Timer" parent="."]
+wait_time = 0.2
+one_shot = true
+
 [connection signal="body_entered" from="." to="." method="_on_body_entered"]
 [connection signal="timeout" from="InvulTimer" to="." method="_on_invul_timer_timeout"]
 [connection signal="timeout" from="WeaponCD" to="." method="_on_weapon_cd_timeout"]
+[connection signal="timeout" from="FlashHitTimer" to="." method="_on_flash_hit_timer_timeout"]

--- a/shaders/flash_hit.gdshader
+++ b/shaders/flash_hit.gdshader
@@ -1,0 +1,10 @@
+shader_type canvas_item;
+
+uniform vec4 flash_color: source_color = vec4(1.0);
+uniform float flash_modifier: hint_range(0.0, 1.0) = 0.5;
+
+void fragment() {
+    vec4 texture_color = texture(TEXTURE, UV);
+	texture_color.rgb = mix(texture_color.rgb, flash_color.rgb, flash_modifier);
+    COLOR = texture_color;
+}

--- a/shaders/flash_hit.gdshader.uid
+++ b/shaders/flash_hit.gdshader.uid
@@ -1,0 +1,1 @@
+uid://bhh5naq1x7pmc


### PR DESCRIPTION
# Changes
- created a basic shader that allows us to modify the whiteness of a sprite's color
- make both the enemy and player flash when they get hit by a projectile
- added a timer to control the duration of the flash effect